### PR TITLE
refactor: Add Notify Slack action

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,24 @@
+name: Notify Slack
+description: Notify Slack on job status
+inputs:
+  slack-webhook-url:
+    description: 'Slack webhook URL'
+    required: true
+  message:
+    description: 'Message to send'
+    required: true
+  type:
+    description: 'Type of message - good, warning or danger'
+    required: false
+    default: 'good'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Call Slack webhook
+      run: node .github/actions/notify-slack/slack-webhook.js
+      shell: bash
+      env:
+        SLACK_WEBHOOK_TEST_CHANNEL: ${{ inputs.slack-webhook-url }}
+        NOTIFY_MESSAGE: ${{ inputs.message }}
+        NOTIFY_TYPE: ${{ inputs.type }}


### PR DESCRIPTION
Add a new action called "Notify Slack" to the repository. This action allows sending notifications to Slack based on job status. It includes inputs for the Slack webhook URL, message to send, and type of message (good, warning, or danger). The action runs a composite job and calls a Node.js script to send the notification.